### PR TITLE
Refactor pipeline

### DIFF
--- a/rust/src/globals.rs
+++ b/rust/src/globals.rs
@@ -8,6 +8,8 @@ pub struct Vertex {
     pub(crate) y: f64,
 }
 
+pub type Edge<'a> = [&'a Vertex; 2];
+
 pub type Color = [u32; CELL_SIZE];
 
 pub struct Shape {

--- a/rust/src/pipeline.rs
+++ b/rust/src/pipeline.rs
@@ -1,23 +1,89 @@
 extern crate wasm_bindgen;
 use crate::{
-    globals::{Matrix3, Vector3, Vertex, CELL_SIZE, NULL_VALUE},
+    globals::{Edge, Matrix3, Vector3, Vertex, CELL_SIZE, NULL_VALUE},
     matrix3::{matrix3_identity, matrix3_transform},
     renderer::Renderer,
 };
+use std::ptr;
 use wasm_bindgen::prelude::*;
 
 fn vertex_processing(vertices: &Vec<Vertex>, m: &Matrix3) -> Vec<Vertex> {
-    let mut transformed_vertices: Vec<Vertex> = vec![];
+    let mut transformed: Vec<Vertex> = vec![];
     for vertex in vertices {
         let v: Vector3 = [vertex.x, vertex.y, 1.0];
         let out: Vector3 = matrix3_transform(&v, &m);
-        transformed_vertices.push(Vertex {
+        transformed.push(Vertex {
             color: vertex.color,
             x: out[0],
             y: out[1],
         })
     }
-    transformed_vertices
+    transformed
+}
+
+fn primitive_assembly(vertices: &Vec<Vertex>) -> Vec<Edge> {
+    if vertices.len() == 0 {
+        vec![]
+    } else if vertices.len() == 1 {
+        let edge: Edge = [&vertices[0], &vertices[0]];
+        vec![edge]
+    } else {
+        let mut edges: Vec<Edge> = vec![];
+        for i in 1..vertices.len() {
+            let from: &Vertex = &vertices[i - 1];
+            let to: &Vertex = &vertices[i];
+            let edge: Edge = [from, to];
+            edges.push(edge);
+        }
+        edges
+    }
+}
+
+fn rasterization(edges: &Vec<Edge>) -> Vec<Vertex> {
+    let mut vertices: Vec<Vertex> = vec![];
+    for edge in edges {
+        let from: &Vertex = edge[0];
+        let to: &Vertex = edge[1];
+        if ptr::eq(from, to) {
+            vertices.push(Vertex {
+                color: from.color,
+                x: from.x,
+                y: from.y,
+            })
+        }
+    }
+    vertices
+}
+
+fn clipping(vertices: &Vec<Vertex>, cols: isize, rows: isize) -> Vec<usize> {
+    let mut clipped: Vec<usize> = vec![];
+    for i in 0..vertices.len() {
+        let vertex: &Vertex = &vertices[i];
+        let x: isize = vertex.x.round() as isize;
+        let y: isize = vertex.y.round() as isize;
+        if x >= 0 && x < cols && y >= 0 && y < rows {
+            clipped.push(i);
+        }
+    }
+    clipped
+}
+
+fn fragment_processing(
+    clipped: &Vec<usize>,
+    vertices: &Vec<Vertex>,
+    buffer: &mut Vec<u32>,
+    cols: isize,
+) {
+    for i in clipped {
+        let vertex: &Vertex = &vertices[*i];
+        let x: isize = vertex.x.round() as isize;
+        let y: isize = vertex.y.round() as isize;
+        let index: usize = ((x + y * cols) as usize) * CELL_SIZE;
+        buffer[index] = vertex.color[0];
+        buffer[index + 1] = vertex.color[1];
+        buffer[index + 2] = vertex.color[2];
+        buffer[index + 3] = vertex.color[3];
+    }
 }
 
 #[wasm_bindgen]
@@ -25,21 +91,11 @@ impl Renderer {
     pub fn render(&mut self) -> *const u32 {
         self.buffer.fill(NULL_VALUE);
         for shape in &self.shapes {
-            let transformed_vertices: Vec<Vertex> =
-                vertex_processing(&shape.vertices, &shape.matrix);
-            for vertex in transformed_vertices {
-                let x: isize = vertex.x.round() as isize;
-                let y: isize = vertex.y.round() as isize;
-                let cols: isize = self.cols as isize;
-                let rows: isize = self.rows as isize;
-                if x >= 0 && x < cols && y >= 0 && y < rows {
-                    let index: usize = ((x + y * cols) as usize) * CELL_SIZE;
-                    self.buffer[index] = vertex.color[0];
-                    self.buffer[index + 1] = vertex.color[1];
-                    self.buffer[index + 2] = vertex.color[2];
-                    self.buffer[index + 3] = vertex.color[3];
-                }
-            }
+            let transformed: Vec<Vertex> = vertex_processing(&shape.vertices, &shape.matrix);
+            let primitive: Vec<Edge> = primitive_assembly(&transformed);
+            let fragment: Vec<Vertex> = rasterization(&primitive);
+            let clipped: Vec<usize> = clipping(&fragment, self.cols as isize, self.rows as isize);
+            fragment_processing(&clipped, &fragment, &mut self.buffer, self.cols as isize);
         }
         self.shapes.clear();
         self.stacks.clear();

--- a/rust/src/primitives.rs
+++ b/rust/src/primitives.rs
@@ -8,16 +8,15 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 impl Renderer {
     pub fn point(&mut self, x: f64, y: f64) {
-        let vertices: Vec<Vertex> = vec![Vertex {
+        let v: Vertex = Vertex {
             color: self.stroke_color,
-            x: x,
-            y: y,
-        }];
-        let point: Shape = Shape {
-            vertices,
-            matrix: self.mode_view,
+            x,
+            y,
         };
-        self.shapes.push(point);
+        self.shapes.push(Shape {
+            vertices: vec![v],
+            matrix: self.mode_view,
+        });
     }
 }
 


### PR DESCRIPTION
# Pipeline

- vertex_processing
- primitive_assembly
- rasterization
- clipping
- fragment_processing

## Notes

- [lifetime](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html) 
- [compare reference](https://users.rust-lang.org/t/is-any-way-to-know-references-are-referencing-the-same-object/9716/7)

```rs
ref1 as *const _ == ref2 as *const _
```
```rs
use std::ptr;
prt::eq(ref1, ref2);
```